### PR TITLE
feat: secret detection UI — warning banner, block send, acknowledge (#32)

### DIFF
--- a/src/renderer/components/FeedbackBar.tsx
+++ b/src/renderer/components/FeedbackBar.tsx
@@ -1,28 +1,61 @@
 import React from 'react'
+import { maskSecret } from '../hooks/useSecretDetection'
+import type { SecretMatch } from '../hooks/useSecretDetection'
 
 interface FeedbackBarProps {
-  secretWarning: string | null
+  secretMatches: SecretMatch[]
+  secretAcknowledged: boolean
+  onAcknowledge: () => void
+  onRemoveSecret: () => void
   qualityScore: number | null
   antiPatternTip: string | null
 }
 
-/** Single-line below-input feedback area. Renders highest-priority item only. */
+/** Single-line (or compact multi-line) below-input feedback area. Renders highest-priority item only. */
 export function FeedbackBar({
-  secretWarning,
+  secretMatches,
+  secretAcknowledged,
+  onAcknowledge,
+  onRemoveSecret,
   qualityScore,
   antiPatternTip,
 }: FeedbackBarProps): React.ReactElement | null {
-  if (secretWarning) {
+  if (secretMatches.length > 0 && !secretAcknowledged) {
+    const first = secretMatches[0]
+    const masked = maskSecret(first.match)
     return (
-      <p
-        role="alert"
-        className="text-xs text-red-400 truncate font-variant-numeric tabular-nums"
-        title={secretWarning}
-      >
-        ⚠️ {secretWarning}
-      </p>
+      <div role="alert" className="flex flex-col gap-1 w-full">
+        <p className="text-xs text-red-400 font-medium">
+          ⚠ Your prompt contains what looks like {first.name} ({masked})
+        </p>
+        <div className="flex gap-2">
+          <button
+            type="button"
+            onClick={onRemoveSecret}
+            className="
+              text-xs text-red-300 border border-red-600 rounded px-2 py-0.5
+              hover:bg-red-900/40 focus:outline-none focus-visible:ring-2 focus-visible:ring-red-500
+              transition-colors
+            "
+          >
+            Remove
+          </button>
+          <button
+            type="button"
+            onClick={onAcknowledge}
+            className="
+              text-xs text-gray-300 border border-gray-600 rounded px-2 py-0.5
+              hover:bg-gray-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-500
+              transition-colors
+            "
+          >
+            I&apos;ve reviewed — send anyway
+          </button>
+        </div>
+      </div>
     )
   }
+
   if (qualityScore !== null) {
     return (
       <p className="text-xs text-gray-400 truncate font-variant-numeric tabular-nums">

--- a/src/renderer/components/Panel.tsx
+++ b/src/renderer/components/Panel.tsx
@@ -3,6 +3,7 @@ import { usePromptStore } from '../stores/promptStore'
 import { usePresetsStore } from '../stores/presetsStore'
 import { useSettingsStore } from '../stores/settingsStore'
 import { usePanelActions } from '../hooks/usePanelActions'
+import { useSecretDetection } from '../hooks/useSecretDetection'
 import { PresetDropdown, detectSlashCommand } from './PresetDropdown'
 import { ModelDropdown } from './ModelDropdown'
 import { TmuxDropdown } from './TmuxDropdown'
@@ -42,6 +43,9 @@ export function Panel({ onOpenSettings }: PanelProps): React.ReactElement {
   const [annotationEnabled, setAnnotationEnabled] = useState(false)
   // Stores the preset active before a slash command override
   const prevPresetRef = useRef<string>(activePreset)
+
+  const { matches: secretMatches, acknowledged: secretAcknowledged, acknowledge } = useSecretDetection(input)
+  const secretBlocked = secretMatches.length > 0 && !secretAcknowledged
 
   const inputRef = useRef<HTMLTextAreaElement>(null)
   const outputRef = useRef<HTMLTextAreaElement>(null)
@@ -97,23 +101,28 @@ export function Panel({ onOpenSettings }: PanelProps): React.ReactElement {
       }
       if (isMeta && e.shiftKey && e.key === 'Enter') {
         e.preventDefault()
-        if (!loading) handleImproveAndSend()
+        if (!loading && !secretBlocked) handleImproveAndSend()
         return
       }
       if (isMeta && e.key === 'Enter') {
         e.preventDefault()
-        if (!loading) handleImprove()
+        if (!loading && !secretBlocked) handleImprove()
         return
       }
     },
-    [loading, handleImprove, handleImproveAndSend],
+    [loading, secretBlocked, handleImprove, handleImproveAndSend],
   )
 
   // Derive feedback bar data (priority: secret warning > score > anti-pattern)
-  const secretWarning = error?.includes('SECRET') ? error : null
-  const qualityScore = !secretWarning && score ? score.overall : null
+  const qualityScore = !secretBlocked && score ? score.overall : null
   const antiPatternTip =
-    !secretWarning && !qualityScore && patterns.length > 0 ? patterns[0].description : null
+    !secretBlocked && !qualityScore && patterns.length > 0 ? patterns[0].description : null
+
+  const handleRemoveSecret = useCallback(() => {
+    if (secretMatches.length === 0) return
+    const first = secretMatches[0]
+    setInput(input.slice(0, first.index) + input.slice(first.index + first.length))
+  }, [secretMatches, input, setInput])
 
   return (
     <div
@@ -177,13 +186,16 @@ export function Panel({ onOpenSettings }: PanelProps): React.ReactElement {
           "
           style={{ fontSize: '16px', touchAction: 'manipulation', fontVariantNumeric: 'tabular-nums' }}
         />
-        <div className="flex items-center justify-between min-h-[18px] flex-shrink-0">
+        <div className="flex items-start justify-between min-h-[18px] flex-shrink-0">
           <FeedbackBar
-            secretWarning={secretWarning}
+            secretMatches={secretMatches}
+            secretAcknowledged={secretAcknowledged}
+            onAcknowledge={acknowledge}
+            onRemoveSecret={handleRemoveSecret}
             qualityScore={qualityScore}
             antiPatternTip={antiPatternTip}
           />
-          {error && !secretWarning && (
+          {error && !secretBlocked && (
             <p className="text-xs text-red-400 truncate ml-2" title={error}>
               {error}
             </p>
@@ -196,7 +208,7 @@ export function Panel({ onOpenSettings }: PanelProps): React.ReactElement {
         <button
           type="button"
           onClick={handleImprove}
-          disabled={loading || !input.trim()}
+          disabled={loading || !input.trim() || secretBlocked}
           aria-label={`Improve prompt (${modKey}+Enter)`}
           className="
             flex items-center justify-center gap-1 flex-1
@@ -214,7 +226,7 @@ export function Panel({ onOpenSettings }: PanelProps): React.ReactElement {
         <button
           type="button"
           onClick={handleImproveAndSend}
-          disabled={loading || !input.trim()}
+          disabled={loading || !input.trim() || secretBlocked}
           aria-label={`Improve and send (${modKey}+Shift+Enter)`}
           className="
             flex items-center justify-center gap-1 flex-1
@@ -292,7 +304,7 @@ export function Panel({ onOpenSettings }: PanelProps): React.ReactElement {
         <button
           type="button"
           onClick={handleSend}
-          disabled={loading || (!output && !input)}
+          disabled={loading || (!output && !input) || secretBlocked}
           aria-label="Send to terminal"
           className="
             flex-shrink-0 bg-green-700 hover:bg-green-600 border border-green-600

--- a/src/renderer/hooks/useSecretDetection.test.ts
+++ b/src/renderer/hooks/useSecretDetection.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest'
+import { maskSecret } from './useSecretDetection'
+
+describe('maskSecret', () => {
+  it('returns first 4 chars + ****', () => {
+    expect(maskSecret('sk-abcdef1234')).toBe('sk-a****')
+  })
+
+  it('handles strings shorter than 4 chars', () => {
+    expect(maskSecret('abc')).toBe('abc****')
+    expect(maskSecret('AB')).toBe('AB****')
+  })
+
+  it('handles strings exactly 4 chars', () => {
+    expect(maskSecret('AKIA')).toBe('AKIA****')
+  })
+
+  it('handles empty string', () => {
+    expect(maskSecret('')).toBe('****')
+  })
+
+  it('masks OpenAI key prefix correctly', () => {
+    const key = `sk-${'a'.repeat(48)}`
+    expect(maskSecret(key)).toBe('sk-a****')
+  })
+
+  it('masks GitHub token prefix correctly', () => {
+    const token = `ghp_${'b'.repeat(36)}`
+    expect(maskSecret(token)).toBe('ghp_****')
+  })
+
+  it('masks AWS key prefix correctly', () => {
+    const key = 'AKIAIOSFODNN7EXAMPLE12'
+    expect(maskSecret(key)).toBe('AKIA****')
+  })
+})

--- a/src/renderer/hooks/useSecretDetection.ts
+++ b/src/renderer/hooks/useSecretDetection.ts
@@ -1,0 +1,55 @@
+import { useState, useEffect, useCallback, useRef } from 'react'
+import { detectSecrets } from '../../core/secrets'
+import type { SecretMatch } from '../../core/secrets'
+
+export type { SecretMatch }
+
+/** Returns "sk-a****" style masked display (first 4 chars + ****). */
+export function maskSecret(raw: string): string {
+  const prefix = raw.slice(0, 4)
+  return `${prefix}****`
+}
+
+export interface UseSecretDetectionResult {
+  matches: SecretMatch[]
+  /** True after user clicks "I've reviewed — send anyway" for the current input value. */
+  acknowledged: boolean
+  /** Call when user clicks "I've reviewed — send anyway". */
+  acknowledge: () => void
+}
+
+/**
+ * Debounced secret detection hook.
+ * Scans inputText for secrets with a 200ms debounce.
+ * Acknowledgment is reset whenever inputText changes.
+ */
+export function useSecretDetection(inputText: string): UseSecretDetectionResult {
+  const [matches, setMatches] = useState<SecretMatch[]>([])
+  const [acknowledged, setAcknowledged] = useState(false)
+  const prevInputRef = useRef<string>(inputText)
+
+  // Reset acknowledgment whenever input changes
+  useEffect(() => {
+    if (inputText !== prevInputRef.current) {
+      setAcknowledged(false)
+      prevInputRef.current = inputText
+    }
+  }, [inputText])
+
+  // Debounced detection — 200ms after last keystroke
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      try {
+        setMatches(detectSecrets(inputText))
+      } catch {
+        // Input exceeds MAX_INPUT_LENGTH or other error; clear matches
+        setMatches([])
+      }
+    }, 200)
+    return () => clearTimeout(timer)
+  }, [inputText])
+
+  const acknowledge = useCallback(() => setAcknowledged(true), [])
+
+  return { matches, acknowledged, acknowledge }
+}


### PR DESCRIPTION
## Summary

- Adds `useSecretDetection(inputText)` hook — debounced 200ms, acknowledge/reset logic, `maskSecret` helper
- Updates `FeedbackBar` to show a red warning banner with partial masking (first 4 chars + ****), plus [Remove] and [I've reviewed — send anyway] action buttons
- Wires into `Panel`: Improve, Improve & Send, and Send buttons are disabled while a secret is detected and unacknowledged; keyboard shortcuts respect the block too
- Acknowledgment resets automatically on any input change (non-dismissable per spec)
- Secret warning takes highest priority over quality score and anti-pattern tips

## Validation

```
pnpm test      → 199 tests, 19 files — all pass (7 new tests for maskSecret)
tsc --noEmit   → clean
```

## Risk / Rollback

- Pure UI feature — no changes to core detection engine or IPC
- FeedbackBar interface changed (old `secretWarning: string | null` → structured props); Panel is the only consumer
- Rollback: revert this PR; no data migration needed

Closes #32